### PR TITLE
Update GET query string

### DIFF
--- a/src/ApiRequest.php
+++ b/src/ApiRequest.php
@@ -112,7 +112,7 @@ class ApiRequest {
         switch ($method) {
             case self::METHOD_GET:
                 if ($hasParams) {
-                    $options['query'] = $params;
+                    $uri = $uri.'?'.$encoded_params;
                 }
                 break;
             //case self::METHOD_DELETE:


### PR DESCRIPTION
When using the cursor function like this:

```php
do {
    $res = $this->api()->tradeApi()->getOrderHistory([
        'category' => 'linear',
        'limit' => 10,
        'cursor' => $cursor
    ]);

    $orders = $orders->merge($res['list'])->unique('orderId');
    $cursor = $res['nextPageCursor'];

} while ($page++ < 3 && $cursor);
```

There are errors with the sha256 signing and authorization with bybit. To explain a bit further:

```php
// Works
$headers = $options['headers'];
$request = new Request('GET', 'https://api.bybit.com/v5/order/history?'.$encoded_params, $headers);
$res = $client->send($request);

// Works
$options2['headers'] = $options['headers'];
$res = $client->get('v5/order/history?'.$encoded_params, $options2);

// Doesn't WorkWorks
$res = $client->get('v5/order/history', $options);
```

The change I have made fixes the issue.